### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ retro-bios
 ==========
 
 Sources and/or disassembly listings to BIOS of ex-USSR PC clones and the like
+
+Sources and/or disassembly listings of the DEC Rainbow 100 BIOS (an early PC with VT100/VT102 capability).


### PR DESCRIPTION
Proposition: i'd like to add DEC Rainbow 100 BIOS listings (preferrably to a separate directory). The Rainbow is an early DOS compatible PC with built-in VT100/VT102 emulation.
